### PR TITLE
Tandem starts

### DIFF
--- a/starterator/making_files.py
+++ b/starterator/making_files.py
@@ -872,6 +872,9 @@ def make_suggested_starts(phage_genes, phage_name, file_path):
     # items to build table
     summary_data = list()
 
+    flagged_startnum_rows = []
+
+
     headers = ["Gene", "Pham\nNum", "Pham\nsize", "Start\nNum","Start\nCoord", "Inform\nAnnots", "Agree vs.\ntop Alt"]
     summary_data.append(headers)
 
@@ -934,6 +937,11 @@ def make_suggested_starts(phage_genes, phage_name, file_path):
 
         summary_data.append(gene_summary)
 
+        # Flag this row if the called start is one of the gene's bad adjacent starts
+        if getattr(gene, "called_start_is_bad", False):
+            flagged_startnum_rows.append(len(summary_data) - 1)
+
+
     story.append(Spacer(1, 12))
 
     text = 'The following table summarizes annotation results with a focus on only those manual ' \
@@ -971,6 +979,13 @@ def make_suggested_starts(phage_genes, phage_name, file_path):
             color_styles.append(('BACKGROUND', (score_column, row), (score_column, row), colors.green))
         else:
             color_styles.append(('BACKGROUND', (score_column, row), (score_column, row), colors.yellow))
+
+    # Coloring in the "Start Num" column if any of the adjacent start flagged genes are present in the phage.
+    start_num_column = 3  # columns: 0 Gene, 1 Pham Num, 2 Pham size, 3 Start Num, 4 Start Coord, 5 Inform Annots, 6 Agree vs top Alt
+    for row in flagged_startnum_rows:
+        color_styles.append(('BACKGROUND', (start_num_column, row), (start_num_column, row), colors.red))
+        color_styles.append(('TEXTCOLOR', (start_num_column, row), (start_num_column, row), colors.white))
+
 
     table.setStyle(TableStyle(full_grid_style))
     table.setStyle(TableStyle(align_styles))

--- a/starterator/making_files.py
+++ b/starterator/making_files.py
@@ -956,7 +956,11 @@ def make_suggested_starts(phage_genes, phage_name, file_path):
            'currently annotated start (as shown in the "Start Num" column) versus the number of manual annotations ' \
            'for the most manually annotated alternative start found in the listed gene. ' \
            'Background color is based on the difference in the two numbers ' \
-           '(green if greater than +3, red if less than -3, and yellow if between +3 and -3).'
+           '(green if greater than +3, red if less than -3, and yellow if between +3 and -3).' \
+           'A corollary to the choosing start guidelines: sometimes the best start leads to the choice ' \
+           'between 2 tandem start codons (i.e. one is right after the other). From a small amount of mass ' \
+           'spec data and some basic biology principles, always choose the second start codon. A Start num square ' \
+           'highlighted in red indicates that the start violates the tandem start rule.'
 
     story.append(Paragraph(text, styles['paragraph']))
     story.append(Spacer(1, 12))

--- a/starterator/making_files.py
+++ b/starterator/making_files.py
@@ -894,6 +894,10 @@ def make_suggested_starts(phage_genes, phage_name, file_path):
 
         # building summary table colm 0 geneID
         gene = phage_genes[gene_id]['gene']
+
+        #debug
+        print(gene.full_name, hasattr(gene, "called_start_is_bad"), getattr(gene, "called_start_is_bad", None))
+
         if gene.pham_no is None:
             continue
         gene_summary = list()

--- a/starterator/phamgene.py
+++ b/starterator/phamgene.py
@@ -587,7 +587,7 @@ class UnPhamGene(PhamGene):
 
 
 
-
+# test change
 
         if self.has_bad_adjacent_candidate_starts:
             print(

--- a/starterator/phamgene.py
+++ b/starterator/phamgene.py
@@ -180,6 +180,8 @@ class Gene(object):
 
 pham_genes = {}
 
+PRINTED_BAD_STARTS = set()
+
 
 def new_PhamGene(db_id, start, stop, orientation, phage_id, name, phage_sequence=None):
     if db_id is None:
@@ -241,7 +243,7 @@ class PhamGene(Gene):
         self.candidate_starts = self.add_candidate_starts()
 
         # --- QC: adjacent-start clusters and "bad starts" (all-but-last in each cluster) ---
-        adjacent_candidate_start_groups = self._find_adjacent_start_groups(self.candidate_starts)
+        self.adjacent_candidate_start_groups = self._find_adjacent_start_groups(self.candidate_starts)
 
         # Flatten clusters into a single "bad starts" list:
         # for each adjacent run [a,b,c], treat [a,b] as bad (drop last), then merge across runs.
@@ -319,7 +321,7 @@ class PhamGene(Gene):
                 starts.append(index)
         return sorted(starts)
 
-    def _find_adjacent_start_groups(self):
+    def _find_adjacent_start_groups(self, candidate_starts):
         """Returns groups of start sites that are adjacent in the same ORF (exactly 3 apart)
 
         groups neighboring start sites, ignoring ones that aren't adjacent
@@ -327,7 +329,7 @@ class PhamGene(Gene):
         bad_starts should NOT be called. Starts where there is at least 1 start codon immediately following it.
         """
 
-        starts_sorted = sorted(self.starts)
+        starts_sorted = sorted(candidate_starts)
         bad_groups = []
         current = [starts_sorted[0]]
 
@@ -572,7 +574,7 @@ class UnPhamGene(PhamGene):
         self.candidate_starts = self.add_candidate_starts()
 
         # --- QC: adjacent-start clusters and "bad starts" (all-but-last in each cluster) ---
-        adjacent_candidate_start_groups = self._find_adjacent_start_groups()
+        self.adjacent_candidate_start_groups = self._find_adjacent_start_groups(self.candidate_starts)
 
         bad = []
         for grp in self.adjacent_candidate_start_groups:
@@ -580,6 +582,13 @@ class UnPhamGene(PhamGene):
                 bad.extend(grp[:-1])
         self.bad_adjacent_candidate_starts = sorted(set(bad))
         self.has_bad_adjacent_candidate_starts = bool(self.bad_adjacent_candidate_starts)
+
+
+
+
+
+
+
         if self.has_bad_adjacent_candidate_starts:
             print(
                 f"[QC] bad adjacent starts (offsets) gene={getattr(self, 'gene_no', getattr(self, 'number', '?'))}: {self.bad_adjacent_candidate_starts}")

--- a/starterator/phamgene.py
+++ b/starterator/phamgene.py
@@ -239,6 +239,17 @@ class PhamGene(Gene):
         self.ahead_of_start = None
         self.sequence = self.make_gene()
         self.candidate_starts = self.add_candidate_starts()
+        # adjacent start checking
+        self.adjacent_candidate_start_groups = self._find_adjacent_start_groups(
+            self.candidate_starts
+        )
+        self.has_adjacent_candidate_starts = bool(self.adjacent_candidate_start_groups)
+
+        #debug during run
+        if self.has_adjacent_candidate_starts:
+            print(
+                f"[QC] gene {getattr(self, 'gene_number', '?')} adjacent starts: {self.adjacent_candidate_start_groups}")
+
         self.alignment = None
         self.alignment_start_site = None
         self.alignment_candidate_starts = None
@@ -301,6 +312,33 @@ class PhamGene(Gene):
             if codon in start_codons:
                 starts.append(index)
         return sorted(starts)
+
+    def _find_adjacent_start_groups(self, starts):
+        """Returns groups of start sites that are adjacent in the same ORF (exactly 3 apart)
+
+        groups neighboring start sites, ignoring ones that aren't adjacent
+
+        bad_starts should NOT be called. Starts where there is at least 1 start codon immediately following it.
+        """
+        if not starts:
+            return []
+        starts_sorted = sorted(starts)
+        bad_groups = []
+        current = [starts_sorted[0]]
+
+        for s in starts_sorted[1:]:
+            if s - current[-1] == 3:
+                current.append(s)
+            else:
+                if len(current) >= 2:
+                    bad_groups.append(current)
+                current = [s]
+
+        if len(current) >= 2:
+            bad_groups.append(current)
+        return bad_groups
+
+
 
     def add_alignment_start_site(self):
         """
@@ -527,6 +565,16 @@ class UnPhamGene(PhamGene):
 
         self.sequence = self.make_gene(phage_sequence)
         self.candidate_starts = self.add_candidate_starts()
+        #adjacent start checking
+        self.adjacent_candidate_start_groups = self._find_adjacent_start_groups(
+            self.candidate_starts
+        )
+        self.has_adjacent_candidate_starts = bool(self.adjacent_candidate_start_groups)
+        # debug during run
+        if self.has_adjacent_candidate_starts:
+            print(
+                f"[QC] gene {getattr(self, 'gene_number', '?')} adjacent starts: {self.adjacent_candidate_start_groups}")
+
         self.alignment = None
         self.alignment_start = None
         self.alignment_candidate_starts = None

--- a/starterator/phamgene.py
+++ b/starterator/phamgene.py
@@ -239,16 +239,22 @@ class PhamGene(Gene):
         self.ahead_of_start = None
         self.sequence = self.make_gene()
         self.candidate_starts = self.add_candidate_starts()
-        # adjacent start checking
-        self.adjacent_candidate_start_groups = self._find_adjacent_start_groups(
-            self.candidate_starts
-        )
-        self.has_adjacent_candidate_starts = bool(self.adjacent_candidate_start_groups)
 
-        #debug during run
-        if self.has_adjacent_candidate_starts:
+        # --- QC: adjacent-start clusters and "bad starts" (all-but-last in each cluster) ---
+        self.adjacent_candidate_start_groups = self._find_adjacent_start_groups(self.candidate_starts)
+
+        # Flatten clusters into a single "bad starts" list:
+        # for each adjacent run [a,b,c], treat [a,b] as bad (drop last), then merge across runs.
+        bad = []
+        for grp in self.adjacent_candidate_start_groups:
+            if len(grp) >= 2:
+                bad.extend(grp[:-1])
+        self.bad_adjacent_candidate_starts = sorted(set(bad))
+        self.has_bad_adjacent_candidate_starts = bool(self.bad_adjacent_candidate_starts)
+
+        if self.has_bad_adjacent_candidate_starts:
             print(
-                f"[QC] gene {getattr(self, 'gene_number', '?')} adjacent starts: {self.adjacent_candidate_start_groups}")
+                f"[QC] bad adjacent starts (offsets) gene={getattr(self, 'gene_no', getattr(self, 'number', '?'))}: {self.bad_adjacent_candidate_starts}")
 
         self.alignment = None
         self.alignment_start_site = None
@@ -565,15 +571,19 @@ class UnPhamGene(PhamGene):
 
         self.sequence = self.make_gene(phage_sequence)
         self.candidate_starts = self.add_candidate_starts()
-        #adjacent start checking
-        self.adjacent_candidate_start_groups = self._find_adjacent_start_groups(
-            self.candidate_starts
-        )
-        self.has_adjacent_candidate_starts = bool(self.adjacent_candidate_start_groups)
-        # debug during run
-        if self.has_adjacent_candidate_starts:
+
+        # --- QC: adjacent-start clusters and "bad starts" (all-but-last in each cluster) ---
+        self.adjacent_candidate_start_groups = self._find_adjacent_start_groups(self.candidate_starts)
+
+        bad = []
+        for grp in self.adjacent_candidate_start_groups:
+            if len(grp) >= 2:
+                bad.extend(grp[:-1])
+        self.bad_adjacent_candidate_starts = sorted(set(bad))
+        self.has_bad_adjacent_candidate_starts = bool(self.bad_adjacent_candidate_starts)
+        if self.has_bad_adjacent_candidate_starts:
             print(
-                f"[QC] gene {getattr(self, 'gene_number', '?')} adjacent starts: {self.adjacent_candidate_start_groups}")
+                f"[QC] bad adjacent starts (offsets) gene={getattr(self, 'gene_no', getattr(self, 'number', '?'))}: {self.bad_adjacent_candidate_starts}")
 
         self.alignment = None
         self.alignment_start = None

--- a/starterator/phamgene.py
+++ b/starterator/phamgene.py
@@ -241,7 +241,7 @@ class PhamGene(Gene):
         self.candidate_starts = self.add_candidate_starts()
 
         # --- QC: adjacent-start clusters and "bad starts" (all-but-last in each cluster) ---
-        self.adjacent_candidate_start_groups = self._find_adjacent_start_groups(self.candidate_starts)
+        adjacent_candidate_start_groups = self._find_adjacent_start_groups(self.candidate_starts)
 
         # Flatten clusters into a single "bad starts" list:
         # for each adjacent run [a,b,c], treat [a,b] as bad (drop last), then merge across runs.
@@ -319,16 +319,15 @@ class PhamGene(Gene):
                 starts.append(index)
         return sorted(starts)
 
-    def _find_adjacent_start_groups(self, starts):
+    def _find_adjacent_start_groups(self):
         """Returns groups of start sites that are adjacent in the same ORF (exactly 3 apart)
 
         groups neighboring start sites, ignoring ones that aren't adjacent
 
         bad_starts should NOT be called. Starts where there is at least 1 start codon immediately following it.
         """
-        if not starts:
-            return []
-        starts_sorted = sorted(starts)
+
+        starts_sorted = sorted(self.starts)
         bad_groups = []
         current = [starts_sorted[0]]
 
@@ -573,7 +572,7 @@ class UnPhamGene(PhamGene):
         self.candidate_starts = self.add_candidate_starts()
 
         # --- QC: adjacent-start clusters and "bad starts" (all-but-last in each cluster) ---
-        self.adjacent_candidate_start_groups = self._find_adjacent_start_groups(self.candidate_starts)
+        adjacent_candidate_start_groups = self._find_adjacent_start_groups()
 
         bad = []
         for grp in self.adjacent_candidate_start_groups:

--- a/starterator/phamgene.py
+++ b/starterator/phamgene.py
@@ -683,15 +683,20 @@ class UnPhamGene(PhamGene):
             return self.pham_no
 
     def blast(self):
-        # not sure where to put this... this makes more sense, 
-        # but I wanted to keep the Genes out of file making...
-        # print "Running BLASTp"
-        try:
-            result_handle = open("%s/%s.xml" % (utils.INTERMEDIATE_DIR, self.gene_id))
-            result_handle.close()
-        except:
+        """
+        Runs BLASTp for this UnPhamGene (if needed) and returns the pham number.
+        Uses cached XML if present, but deletes it if it's empty (common failure case).
+        """
+        xml_path = os.path.join(utils.INTERMEDIATE_DIR, f"{self.gene_id}.xml")
+
+        # If cached XML exists but is empty, delete it so BLAST reruns
+        if os.path.exists(xml_path) and os.path.getsize(xml_path) == 0:
+            os.remove(xml_path)
+
+        # If XML doesn't exist, run BLAST
+        if not os.path.exists(xml_path):
             protein = SeqRecord(self.sequence[self.candidate_starts[0]:].seq.translate(), id=self.gene_id)
-            # print protein, self.sequence
+
             # short proteins need lower e_value
             query_len = (self.stop - self.start) / 3
             if query_len < 50:
@@ -699,34 +704,48 @@ class UnPhamGene(PhamGene):
             else:
                 e_value = math.pow(10, -20)
 
-            SeqIO.write(protein, '%s/%s.fasta' % (utils.INTERMEDIATE_DIR, self.gene_id), 'fasta')
-            # Using subprocess approach instead of deprecated Bio.Application
-            blast_args = ["%sblastp" % utils.BLAST_DIR,
-                          "-out", '%s/%s.xml' % (utils.INTERMEDIATE_DIR, self.gene_id),
-                          "-outfmt", "5",
-                          "-query", '%s/%s.fasta' % (utils.INTERMEDIATE_DIR, self.gene_id),
-                          "-db", "\"%s/Proteins.fasta\"" % (utils.PROTEIN_DB),
-                          "-evalue", str(e_value)
-                          ]
-            # print " ".join(blast_args)
+            fasta_path = os.path.join(utils.INTERMEDIATE_DIR, f"{self.gene_id}.fasta")
+            SeqIO.write(protein, fasta_path, "fasta")
+
+            db_path = os.path.join(utils.PROTEIN_DB, "Proteins.fasta")  # no quotes
+            # Ensure the BLAST database exists (makeblastdb outputs)
+            db_required = [db_path + ext for ext in (".pin", ".psq", ".phr")]
+            if not all(os.path.exists(p) for p in db_required):
+                update_protein_db()
+
+            blast_args = [
+                os.path.join(utils.BLAST_DIR, "blastp"),
+                "-out", xml_path,
+                "-outfmt", "5",
+                "-query", fasta_path,
+                "-db", db_path,
+                "-evalue", str(e_value),
+            ]
+
             try:
                 subprocess.check_call(blast_args)
-            except:
-                raise StarteratorError("Blast could not run!")
-        # print blast_command
-        # stdout, stderr = blast_command()
+            except Exception as e:
+                raise StarteratorError(f"Blast could not run! ({e})")
+
+            # If BLAST produced an empty XML anyway, fail clearly
+            if not os.path.exists(xml_path) or os.path.getsize(xml_path) == 0:
+                raise StarteratorError("BLAST produced an empty XML output file.")
+
         return self.parse_blast()
 
     def parse_blast(self):
-        result_handle = open("%s/%s.xml" % (utils.INTERMEDIATE_DIR, self.gene_id))
+        # Always read the BLAST XML from the intermediate directory.
+        xml_path = os.path.join(utils.INTERMEDIATE_DIR, f"{self.gene_id}.xml")
 
+        # First try: NCBIXML.read (expects exactly one record)
         try:
-            blast_record = NCBIXML.read(result_handle)
+            with open(xml_path, "r") as result_handle:
+                blast_record = NCBIXML.read(result_handle)
         except:
-            result_handle.close()
-            result_handle = open('%s/%s.xml' % (self.output_dir, self.name))
-            blast_records = NCBIXML.parse(result_handle)
-            blast_record = next(blast_records)
+            # Fallback: NCBIXML.parse (iterator) in case file contains multiple records
+            with open(xml_path, "r") as result_handle:
+                blast_records = NCBIXML.parse(result_handle)
+                blast_record = next(blast_records)
 
         if len(blast_record.descriptions) > 0:
             first_result = blast_record.descriptions[0].title.split(',')[0].split(' ')[-1]

--- a/starterator/phamgene.py
+++ b/starterator/phamgene.py
@@ -254,9 +254,13 @@ class PhamGene(Gene):
         self.bad_adjacent_candidate_starts = sorted(set(bad))
         self.has_bad_adjacent_candidate_starts = bool(self.bad_adjacent_candidate_starts)
 
+
+        '''
         if self.has_bad_adjacent_candidate_starts:
             print(
                 f"[QC] bad adjacent starts (offsets) gene={getattr(self, 'gene_no', getattr(self, 'number', '?'))}: {self.bad_adjacent_candidate_starts}")
+        '''
+
 
         self.alignment = None
         self.alignment_start_site = None
@@ -444,7 +448,50 @@ class PhamGene(Gene):
 
         self.alignment_annot_counts_by_start = dict(zip(self.alignment_annot_start_nums, self.alignment_annot_start_counts))
 
+
+        # ---- Adjacent-start QC: determine whether the CALLED start is one of the bad ones ----
+        # bad_adjacent_candidate_starts are OFFSETS (bp) in self.sequence coordinates (0-based into gene sequence)
+        # We want to flag only if the called start corresponds to one of those "bad" offsets (NOT the last in a run).
+
+        self.bad_adjacent_start_nums = []
+        self.called_start_is_bad = False
+
+        try:
+            # offset(bp) -> alignment index
+            if self.candidate_starts and self.alignment_candidate_starts:
+                offset_to_aln = dict(zip(self.candidate_starts, self.alignment_candidate_starts))
+            else:
+                offset_to_aln = {}
+
+            total_possible = getattr(pham, "total_possible_starts", None)
+
+            if total_possible and offset_to_aln and getattr(self, "bad_adjacent_candidate_starts", None):
+                bad_nums = set()
+
+                for off in self.bad_adjacent_candidate_starts:
+                    aln_idx = offset_to_aln.get(off)
+                    if aln_idx is None:
+                        continue
+                    if aln_idx in total_possible:
+                        # start num is 1-based index into total_possible
+                        bad_nums.add(total_possible.index(aln_idx) + 1)
+
+                self.bad_adjacent_start_nums = sorted(bad_nums)
+
+                # Only flag red if CALLED start num is one of the bad nums.
+                self.called_start_is_bad = (self.alignment_start_num_called in bad_nums)
+
+        except Exception:
+            # keep defaults if anything goes wrong
+            self.bad_adjacent_start_nums = []
+            self.called_start_is_bad = False
+
+
         return
+
+
+
+
 
     def alignment_index_to_coord(self, index):
         """
@@ -589,9 +636,12 @@ class UnPhamGene(PhamGene):
 
 # test change
 
+        '''
         if self.has_bad_adjacent_candidate_starts:
             print(
                 f"[QC] bad adjacent starts (offsets) gene={getattr(self, 'gene_no', getattr(self, 'number', '?'))}: {self.bad_adjacent_candidate_starts}")
+        '''
+
 
         self.alignment = None
         self.alignment_start = None

--- a/starterator/phamgene.py
+++ b/starterator/phamgene.py
@@ -243,7 +243,7 @@ class PhamGene(Gene):
         self.candidate_starts = self.add_candidate_starts()
 
         # --- QC: adjacent-start clusters and "bad starts" (all-but-last in each cluster) ---
-        self.adjacent_candidate_start_groups = self._find_adjacent_start_groups(self.candidate_starts)
+        self.adjacent_candidate_start_groups = self._find_adjacent_start_groups()
 
         # Flatten clusters into a single "bad starts" list:
         # for each adjacent run [a,b,c], treat [a,b] as bad (drop last), then merge across runs.
@@ -321,7 +321,7 @@ class PhamGene(Gene):
                 starts.append(index)
         return sorted(starts)
 
-    def _find_adjacent_start_groups(self, candidate_starts):
+    def _find_adjacent_start_groups(self):
         """Returns groups of start sites that are adjacent in the same ORF (exactly 3 apart)
 
         groups neighboring start sites, ignoring ones that aren't adjacent
@@ -329,7 +329,7 @@ class PhamGene(Gene):
         bad_starts should NOT be called. Starts where there is at least 1 start codon immediately following it.
         """
 
-        starts_sorted = sorted(candidate_starts)
+        starts_sorted = sorted(self.candidate_starts)
         bad_groups = []
         current = [starts_sorted[0]]
 
@@ -574,7 +574,7 @@ class UnPhamGene(PhamGene):
         self.candidate_starts = self.add_candidate_starts()
 
         # --- QC: adjacent-start clusters and "bad starts" (all-but-last in each cluster) ---
-        self.adjacent_candidate_start_groups = self._find_adjacent_start_groups(self.candidate_starts)
+        self.adjacent_candidate_start_groups = self._find_adjacent_start_groups()
 
         bad = []
         for grp in self.adjacent_candidate_start_groups:

--- a/starterator/phamgene.py
+++ b/starterator/phamgene.py
@@ -242,7 +242,7 @@ class PhamGene(Gene):
         self.sequence = self.make_gene()
         self.candidate_starts = self.add_candidate_starts()
 
-        # --- QC: adjacent-start clusters and "bad starts" (all-but-last in each cluster) ---
+        #adjacent-start clusters and "bad starts" (all-but-last in each cluster)
         self.adjacent_candidate_start_groups = self._find_adjacent_start_groups()
 
         # Flatten clusters into a single "bad starts" list:
@@ -449,7 +449,7 @@ class PhamGene(Gene):
         self.alignment_annot_counts_by_start = dict(zip(self.alignment_annot_start_nums, self.alignment_annot_start_counts))
 
 
-        # ---- Adjacent-start QC: determine whether the CALLED start is one of the bad ones ----
+        #Adjacent-start checking: determine whether the CALLED start is one of the bad ones
         # bad_adjacent_candidate_starts are OFFSETS (bp) in self.sequence coordinates (0-based into gene sequence)
         # We want to flag only if the called start corresponds to one of those "bad" offsets (NOT the last in a run).
 
@@ -620,7 +620,7 @@ class UnPhamGene(PhamGene):
         self.sequence = self.make_gene(phage_sequence)
         self.candidate_starts = self.add_candidate_starts()
 
-        # --- QC: adjacent-start clusters and "bad starts" (all-but-last in each cluster) ---
+        #find all but the last start
         self.adjacent_candidate_start_groups = self._find_adjacent_start_groups()
 
         bad = []
@@ -634,12 +634,10 @@ class UnPhamGene(PhamGene):
 
 
 
-# test change
-
         '''
         if self.has_bad_adjacent_candidate_starts:
             print(
-                f"[QC] bad adjacent starts (offsets) gene={getattr(self, 'gene_no', getattr(self, 'number', '?'))}: {self.bad_adjacent_candidate_starts}")
+                f"bad adjacent starts (offsets) gene={getattr(self, 'gene_no', getattr(self, 'number', '?'))}: {self.bad_adjacent_candidate_starts}")
         '''
 
 
@@ -685,7 +683,7 @@ class UnPhamGene(PhamGene):
     def blast(self):
         """
         Runs BLASTp for this UnPhamGene (if needed) and returns the pham number.
-        Uses cached XML if present, but deletes it if it's empty (common failure case).
+        Uses cached XML if present, but deletes it if it's empty (common point of failure).
         """
         xml_path = os.path.join(utils.INTERMEDIATE_DIR, f"{self.gene_id}.xml")
 

--- a/starterator/report.py
+++ b/starterator/report.py
@@ -365,6 +365,7 @@ class UnPhamPhageReport(PhageReport):
                     self.phage_genes[int(gene_no)] = {'pham_no': None, "gene": gene, "suggested_start": None}
             pham_counter += 1
 
+#test change 2
 
 class GeneReport(Report):
     def __init__(self, phage_name, number=None, whole_phage=False, fasta_file=None):

--- a/starterator/report.py
+++ b/starterator/report.py
@@ -207,21 +207,38 @@ class UnPhamPhageReport(PhageReport):
                     with open(self.profile, "r") as profile:
                         # print self.profile, "has been opened!"
                         first_line = profile.readline()
-                        first_word = first_line.split()[0]
+
+                        # ---- CHANGE 1: make first_word parsing robust (avoid crash on blank/whitespace) ----
+                        first_word = first_line.split()[0] if first_line.strip() else ""
+
                         if first_word == "Profile":
+                            # ---- CHANGE 2: reset file pointer so csv_reader includes the first line again ----
+                            profile.seek(0)
+
                             csv_reader = csv.reader(profile)
-                            line = next(csv_reader)
+                            line = next(csv_reader)  # header 1
                             #  print line
-                            next(csv_reader)
+                            next(csv_reader)  # header 2
+
                             for row in csv_reader:
+                                # ---- CHANGE 3: guard against short/blank rows ----
+                                if len(row) < 9:
+                                    continue
+
                                 # print row
                                 feature_type = row[8].strip()
                                 #  print feature_type
                                 if feature_type == "ORF":
                                     number = row[1].replace('"', "")
                                     orientation = row[2]
-                                    start = int(row[5])
-                                    stop = int(row[6])
+
+                                    # ---- CHANGE 4: guard numeric parsing ----
+                                    try:
+                                        start = int(row[5])
+                                        stop = int(row[6])
+                                    except:
+                                        continue
+
                                     # print number, start, stop, orientation, self.name
                                     gene = phamgene.UnPhamGene(number, start, stop, orientation, self.name, sequence)
                                     genes.append(gene)
@@ -251,16 +268,27 @@ class UnPhamPhageReport(PhageReport):
                                             line3 = line2.replace(")", "")
                                             line_items = line3.split()
 
+                                            # ---- CHANGE 5: guard against malformed CDS lines ----
+                                            if len(line_items) < 4:
+                                                continue
+
                                             if line_items[1] == "complement":
                                                 gene_orientation = "R"
-                                                gene_start = int(line_items[2])
-                                                gene_end = int(line_items[4])
-
+                                                try:
+                                                    gene_start = int(line_items[2])
+                                                    gene_end = int(line_items[4])
+                                                except:
+                                                    continue
                                             else:
                                                 gene_orientation = "F"
-                                                gene_start = int(line_items[1])
-                                                gene_end = int(line_items[3])
-                                        gene = phamgene.UnPhamGene(gene_count, gene_start, gene_end, gene_orientation, self.name, sequence)
+                                                try:
+                                                    gene_start = int(line_items[1])
+                                                    gene_end = int(line_items[3])
+                                                except:
+                                                    continue
+
+                                        gene = phamgene.UnPhamGene(gene_count, gene_start, gene_end, gene_orientation,
+                                                                   self.name, sequence)
                                         genes.append(gene)
                                         pham_no = gene.phambymatch()
                                         if pham_no is None:
@@ -276,9 +304,18 @@ class UnPhamPhageReport(PhageReport):
                                     else:
                                         continue
                             else:
-                                raise StarteratorError("The profile file (%s) could not be read correctly! Please make sure it is correct." % self.profile)
-                except:
-                    raise StarteratorError("The profile file (%s) could not be read correctly! Please make sure it is correct." % self.profile)
+                                raise StarteratorError(
+                                    "The profile file (%s) could not be read correctly! Please make sure it is correct." % self.profile
+                                )
+
+                # ---- CHANGE 6: don't swallow the real exception type/message ----
+                except StarteratorError:
+                    raise
+                except Exception as e:
+                    raise StarteratorError(
+                        "The profile file (%s) could not be read correctly! (%s)" % (self.profile, str(e))
+                    )
+
         return self._phams
 
     def get_cluster(self):

--- a/starterator/report.py
+++ b/starterator/report.py
@@ -402,7 +402,6 @@ class UnPhamPhageReport(PhageReport):
                     self.phage_genes[int(gene_no)] = {'pham_no': None, "gene": gene, "suggested_start": None}
             pham_counter += 1
 
-#test change 2
 
 class GeneReport(Report):
     def __init__(self, phage_name, number=None, whole_phage=False, fasta_file=None):


### PR DESCRIPTION
Changes were made to ensure that when there are tandem (adjacent starts), only the very last start in the sequence will be selected. This follows phagesdb guidelines. There was also code added to highlight the "Start site" column square in red if an incorrect tandem start choice was made.